### PR TITLE
Fix Oracle Last-Modified headers

### DIFF
--- a/oracle/stow_test.go
+++ b/oracle/stow_test.go
@@ -1,6 +1,7 @@
 package swift
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/graymeta/stow"
@@ -15,4 +16,32 @@ func TestStow(t *testing.T) {
 	}
 
 	test.All(t, "oracle", cfg)
+}
+
+func TestGetItemUTCLastModified(t *testing.T) {
+	cfg := stow.ConfigMap{
+		"username":        "corey@graymeta.com",
+		"password":        "BHBmQ585mbctcfvD",
+		"identity_domain": "storage-a422618",
+	}
+	tr := http.DefaultTransport
+	http.DefaultTransport = &bogusLastModifiedTransport{tr}
+	defer func() {
+		http.DefaultTransport = tr
+	}()
+
+	test.All(t, "oracle", cfg)
+}
+
+type bogusLastModifiedTransport struct {
+	http.RoundTripper
+}
+
+func (t *bogusLastModifiedTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	res, err := t.RoundTripper.RoundTrip(r)
+	if err != nil {
+		return res, err
+	}
+	res.Header.Set("Last-Modified", "Tue, 23 Aug 2016 15:12:44 UTC")
+	return res, err
 }


### PR DESCRIPTION
Oracle's SWIFT implementation returns Last-Modified headers with "UTC"
timezone, which will cause an error when trying to parse the time with
net/http.TimeFormat because the TZ should be "GMT" instead of "UTC".

Since the parsing is done within the `swift` package we depend on, we
are fixing the headers with a custom transport until we can raise the
issue with the maintainer of our dependency.
