### PR TITLE
Oracle: modified TestGetItemUTCLastModified to use Metered creds

### DIFF
--- a/oracle/stow_test.go
+++ b/oracle/stow_test.go
@@ -31,7 +31,7 @@ func TestGetItemUTCLastModified(t *testing.T) {
 		http.DefaultTransport = tr
 	}()
 
-	test.All(t, "oracle", cfgUnmetered)
+	test.All(t, "oracle", cfgMetered)
 }
 
 type bogusLastModifiedTransport struct {


### PR DESCRIPTION
In stow_test.go, there's a unit test which basically runs the test suite but adds a custom http.Header to unit test the LastModified date.

This was using Oracle's "Unmetered" storage subscription type rather than "Metered". This change switches the creds used to "Metered", which eliminates the finicky test runs that Oracle has been having.
