### PR TITLE
Remove credentials

### DIFF
--- a/swift/stow_test.go
+++ b/swift/stow_test.go
@@ -1,6 +1,7 @@
 package swift
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -11,10 +12,10 @@ import (
 
 func TestStow(t *testing.T) {
 	cfg := stow.ConfigMap{
-		"username":        "sek-chai",
-		"key":             "W33C6CNESJRE3H3FW67MLNNBERZRR4AGYDROX56LX2XWE4GQZC7YNS4CJEF4MPCYVYMJYPARZVUDNBOUI2XRRYWU4HTBPKQ4Q6NX",
-		"tenant_name":     "graymeta-demo-account",
-		"tenant_auth_url": "https://lax-01.identity.sohonet.com/v2.0/",
+		"username":        os.Getenv("SWIFTUSERNAME"),
+		"key":             os.Getenv("SWIFTKEY"),
+		"tenant_name":     os.Getenv("SWIFTTENANTNAME"),
+		"tenant_auth_url": os.Getenv("SWIFTTENANTAUTHURL"),
 		//"tenant_id":       "b04239c7467548678b4822e9dad96030",
 	}
 	test.All(t, "swift", cfg)


### PR DESCRIPTION
Environmental variables needed to run tests will be available on `all-developers` channel.

References #88 

The next step will be to squash commit history.
