### PR TITLE
Expose google.Item with storage object getter

### DIFF
--- a/google/container.go
+++ b/google/container.go
@@ -50,7 +50,7 @@ func (c *container) Item(id string) (stow.Item, error) {
 		return nil, err
 	}
 
-	i := &item{
+	i := &Item{
 		name:         id,
 		container:    c,
 		client:       c.client,
@@ -60,6 +60,7 @@ func (c *container) Item(id string) (stow.Item, error) {
 		lastModified: t,
 		url:          u,
 		metadata:     mdParsed,
+		object:       res,
 	}
 
 	return i, nil
@@ -101,7 +102,7 @@ func (c *container) Items(prefix string, cursor string, count int) ([]stow.Item,
 			return nil, "", err
 		}
 
-		containerItems[i] = &item{
+		containerItems[i] = &Item{
 			name:         o.Name,
 			container:    c,
 			client:       c.client,
@@ -155,7 +156,7 @@ func (c *container) Put(name string, r io.Reader, size int64, metadata map[strin
 		return nil, err
 	}
 
-	newItem := &item{
+	newItem := &Item{
 		name:         name,
 		container:    c,
 		client:       c.client,

--- a/google/item.go
+++ b/google/item.go
@@ -10,7 +10,7 @@ import (
 	storage "google.golang.org/api/storage/v1"
 )
 
-type item struct {
+type Item struct {
 	container    *container       // Container information is required by a few methods.
 	client       *storage.Service // A client is needed to make requests.
 	name         string
@@ -20,30 +20,31 @@ type item struct {
 	url          *url.URL
 	lastModified time.Time
 	metadata     map[string]interface{}
+	object       *storage.Object
 }
 
 // ID returns a string value that represents the name of a file.
-func (i *item) ID() string {
+func (i *Item) ID() string {
 	return i.name
 }
 
 // Name returns a string value that represents the name of the file.
-func (i *item) Name() string {
+func (i *Item) Name() string {
 	return i.name
 }
 
 // Size returns the size of an item in bytes.
-func (i *item) Size() (int64, error) {
+func (i *Item) Size() (int64, error) {
 	return i.size, nil
 }
 
 // URL returns a url which follows the predefined format
-func (i *item) URL() *url.URL {
+func (i *Item) URL() *url.URL {
 	return i.url
 }
 
 // Open returns an io.ReadCloser to the object. Useful for downloading/streaming the object.
-func (i *item) Open() (io.ReadCloser, error) {
+func (i *Item) Open() (io.ReadCloser, error) {
 	res, err := i.client.Objects.Get(i.container.name, i.name).Download()
 	if err != nil {
 		return nil, err
@@ -53,19 +54,24 @@ func (i *item) Open() (io.ReadCloser, error) {
 }
 
 // LastMod returns the last modified date of the item.
-func (i *item) LastMod() (time.Time, error) {
+func (i *Item) LastMod() (time.Time, error) {
 	return i.lastModified, nil
 }
 
 // Metadata returns a nil map and no error.
 // TODO: Implement this.
-func (i *item) Metadata() (map[string]interface{}, error) {
+func (i *Item) Metadata() (map[string]interface{}, error) {
 	return i.metadata, nil
 }
 
 // ETag returns the ETag value
-func (i *item) ETag() (string, error) {
+func (i *Item) ETag() (string, error) {
 	return i.etag, nil
+}
+
+// Object returns the Google Storage Object
+func (i *Item) Object() *storage.Object {
+	return i.object
 }
 
 // prepUrl takes a MediaLink string and returns a url

--- a/google/item.go
+++ b/google/item.go
@@ -70,7 +70,7 @@ func (i *Item) ETag() (string, error) {
 }
 
 // Object returns the Google Storage Object
-func (i *Item) Object() *storage.Object {
+func (i *Item) StorageObject() *storage.Object {
 	return i.object
 }
 


### PR DESCRIPTION
Allows stow.Item to be casted into the google.Item underlying type, which exposes the storage.Object associated with the Item via the Object() getter.