### PR TITLE
Test io.Seeker items work with http.ServeContent

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -280,6 +281,12 @@ func readItemContents(is is.I, item stow.Item) string {
 	r, err := item.Open()
 	is.NoErr(err)
 	defer r.Close()
+	if s, ok := r.(io.Seeker); ok {
+		_, err = s.Seek(0, io.SeekEnd)
+		is.NoErr(err)
+		_, err = s.Seek(0, io.SeekStart)
+		is.NoErr(err)
+	}
 	b, err := ioutil.ReadAll(r)
 	is.NoErr(err)
 	return string(b)


### PR DESCRIPTION
net/http.ServeContent function takes an io.ReadSeeker, which can be
used to serve ranged content.

The function uses `Seek(0, io.SeekEnd)` to establish the total size of
the served content and then resets the seeker with `Seek(0, io.SeekStart)`.

Any stow item that returns an io.Seeker should be able to work with
those two methods.