### PR TITLE
Allow caller to pass scope and reduce default scopes to RW for google.

### DIFF
--- a/google/README.md
+++ b/google/README.md
@@ -42,6 +42,15 @@ if gsBucket, ok := stowBucket.(*stowgs.Bucket); ok {
 }
 ```
 
+By default, Stow uses `https://www.googleapis.com/auth/devstorage.read_write` scope. Different scopes can be used by passing a comma separated list of scopes, like below:
+```go
+stowLoc, err := stow.Dial(stowgs.Kind, stow.ConfigMap{
+	stowgs.ConfigJSON:      "<json config>",
+	stowgs.ConfigProjectId: "<project id>",
+	stowgs.ConfigScopes:    "<scope_1>,<scope_2>",
+})
+```
+
 ---
 
 Configuration... You need to create a project in google, and then create a service account in google tied to that project. You will need to download a `.json` file with the configuration for the service account. To run the test suite, the service account will need edit privileges inside the project.

--- a/google/config.go
+++ b/google/config.go
@@ -3,6 +3,7 @@ package google
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/graymeta/stow"
 	"golang.org/x/net/context"
@@ -17,6 +18,7 @@ const (
 	// The service account json blob
 	ConfigJSON      = "json"
 	ConfigProjectId = "project_id"
+	ConfigScopes    = "scopes"
 )
 
 func init() {
@@ -58,7 +60,12 @@ func init() {
 func newGoogleStorageClient(config stow.Config) (*storage.Service, error) {
 	json, _ := config.Config(ConfigJSON)
 
-	jwtConf, err := google.JWTConfigFromJSON([]byte(json), storage.DevstorageFullControlScope)
+	scopes := []string{storage.DevstorageReadWriteScope}
+	if s, ok := config.Config(ConfigScopes); ok && s != "" {
+		scopes = strings.Split(s, ",")
+	}
+
+	jwtConf, err := google.JWTConfigFromJSON([]byte(json), scopes...)
 
 	service, err := storage.New(jwtConf.Client(context.Background()))
 	if err != nil {


### PR DESCRIPTION
ref:
https://cloud.google.com/storage/docs/json_api/v1/buckets/insert