### PR TITLE
Add Browse() api to list items by folder

### DIFF
--- a/azure/container.go
+++ b/azure/container.go
@@ -50,9 +50,10 @@ func (c *container) Item(id string) (stow.Item, error) {
 	return item, nil
 }
 
-func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+func (c *container) Browse(prefix, delimiter, cursor string, count int) (*stow.ItemPage, error) {
 	params := az.ListBlobsParameters{
 		Prefix:     prefix,
+		Delimiter:  delimiter,
 		MaxResults: uint(count),
 	}
 	if cursor != "" {
@@ -60,8 +61,14 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 	}
 	listblobs, err := c.client.ListBlobs(c.id, params)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
+
+	prefixes := make([]string, len(listblobs.BlobPrefixes))
+	for i, prefix := range listblobs.BlobPrefixes {
+		prefixes[i] = prefix
+	}
+
 	items := make([]stow.Item, len(listblobs.Blobs))
 	for i, blob := range listblobs.Blobs {
 
@@ -75,7 +82,15 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 			properties: blob.Properties,
 		}
 	}
-	return items, listblobs.NextMarker, nil
+	return &stow.ItemPage{Prefixes: prefixes, Items: items, Cursor: listblobs.NextMarker}, nil
+}
+
+func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+	page, err := c.Browse(prefix, "", cursor, count)
+	if err != nil {
+		return nil, "", err
+	}
+	return page.Items, cursor, err
 }
 
 func (c *container) Put(name string, r io.Reader, size int64, metadata map[string]interface{}) (stow.Item, error) {

--- a/google/container.go
+++ b/google/container.go
@@ -70,11 +70,9 @@ func (c *Container) Item(id string) (stow.Item, error) {
 	return i, nil
 }
 
-// Items retrieves a list of items that are prepended with
-// the prefix argument. The 'cursor' variable facilitates pagination.
-func (c *Container) Items(prefix string, cursor string, count int) ([]stow.Item, string, error) {
+func (c *Container) Browse(prefix string, delimiter string, cursor string, count int) (*stow.ItemPage, error) {
 	// List all objects in a bucket using pagination
-	call := c.client.Objects.List(c.name).MaxResults(int64(count))
+	call := c.client.Objects.List(c.name).Delimiter(delimiter).MaxResults(int64(count))
 
 	if prefix != "" {
 		call.Prefix(prefix)
@@ -86,24 +84,29 @@ func (c *Container) Items(prefix string, cursor string, count int) ([]stow.Item,
 
 	res, err := call.Do()
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	containerItems := make([]stow.Item, len(res.Items))
 
+	prefixes := make([]string, len(res.Prefixes))
+	for i, prefix := range res.Prefixes {
+		prefixes[i] = prefix
+	}
+
+	containerItems := make([]stow.Item, len(res.Items))
 	for i, o := range res.Items {
 		t, err := time.Parse(time.RFC3339, o.Updated)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		u, err := prepUrl(o.MediaLink)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		mdParsed, err := parseMetadata(o.Metadata)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		containerItems[i] = &Item{
@@ -120,7 +123,17 @@ func (c *Container) Items(prefix string, cursor string, count int) ([]stow.Item,
 		}
 	}
 
-	return containerItems, res.NextPageToken, nil
+	return &stow.ItemPage{Prefixes: prefixes, Items: containerItems, Cursor: res.NextPageToken}, nil
+}
+
+// Items retrieves a list of items that are prepended with
+// the prefix argument. The 'cursor' variable facilitates pagination.
+func (c *Container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+	page, err := c.Browse(prefix, "", cursor, count)
+	if err != nil {
+		return nil, "", err
+	}
+	return page.Items, cursor, err
 }
 
 func (c *Container) RemoveItem(id string) error {

--- a/s3/container.go
+++ b/s3/container.go
@@ -35,25 +35,28 @@ func (c *container) Item(id string) (stow.Item, error) {
 	return c.getItem(id)
 }
 
-// Items sends a request to retrieve a list of items that are prepended with
-// the prefix argument. The 'cursor' variable facilitates pagination.
-func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+func (c *container) Browse(prefix, delimiter, cursor string, count int) (*stow.ItemPage, error) {
 	itemLimit := int64(count)
 
 	params := &s3.ListObjectsInput{
-		Bucket:  aws.String(c.Name()),
-		Marker:  &cursor,
-		MaxKeys: &itemLimit,
-		Prefix:  &prefix,
+		Bucket:    aws.String(c.Name()),
+		Delimiter: aws.String(delimiter),
+		Marker:    &cursor,
+		MaxKeys:   &itemLimit,
+		Prefix:    &prefix,
 	}
 
 	response, err := c.client.ListObjects(params)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "Items, listing objects")
+		return nil, errors.Wrap(err, "Items, listing objects")
+	}
+
+	prefixes := make([]string, len(response.CommonPrefixes))
+	for i, prefix := range response.CommonPrefixes {
+		prefixes[i] = *prefix.Prefix
 	}
 
 	containerItems := make([]stow.Item, len(response.Contents)) // Allocate space for the Item slice.
-
 	for i, object := range response.Contents {
 		etag := cleanEtag(*object.ETag) // Copy etag value and remove the strings.
 		object.ETag = &etag             // Assign the value to the object field representing the item.
@@ -81,7 +84,17 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 		marker = containerItems[len(containerItems)-1].Name()
 	}
 
-	return containerItems, marker, nil
+	return &stow.ItemPage{Prefixes: prefixes, Items: containerItems, Cursor: marker}, nil
+}
+
+// Items sends a request to retrieve a list of items that are prepended with
+// the prefix argument. The 'cursor' variable facilitates pagination.
+func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+	page, err := c.Browse(prefix, "", cursor, count)
+	if err != nil {
+		return nil, "", err
+	}
+	return page.Items, cursor, err
 }
 
 func (c *container) RemoveItem(id string) error {

--- a/stow.go
+++ b/stow.go
@@ -82,6 +82,22 @@ type Container interface {
 	Name() string
 	// Item gets an item by its ID.
 	Item(id string) (Item, error)
+	// Browse gets a page of prefixes and items with the specified
+	// prefix and delimiter for this Container.
+	// The specified cursor is a pointer to the start of
+	// the items to get. It it obtained from a previous
+	// call to this method, or should be CursorStart for the
+	// first page.
+	// delimiter returns results in a directory-like fashion.
+	// Results will contain only items whose names, aside from the
+	// prefix, do not contain delimiter. Items whose names,
+	// aside from the prefix, contain delimiter will have their name,
+	// truncated after the delimiter, returned in prefixes.
+	// Duplicate prefixes are omitted. Optional.
+	// count is the number of items to return per page.
+	// The returned cursor can be checked with IsCursorEnd to
+	// decide if there are any more items or not.
+	Browse(prefix, delimiter, cursor string, count int) (*ItemPage, error)
 	// Items gets a page of items with the specified
 	// prefix for this Container.
 	// The specified cursor is a pointer to the start of
@@ -91,6 +107,7 @@ type Container interface {
 	// count is the number of items to return per page.
 	// The returned cursor can be checked with IsCursorEnd to
 	// decide if there are any more items or not.
+	// Items is a shortcut for Browse where delimeter is not set.
 	Items(prefix, cursor string, count int) ([]Item, string, error)
 	// RemoveItem removes the Item with the specified ID.
 	RemoveItem(id string) error
@@ -126,6 +143,12 @@ type Item interface {
 	// Metadata gets a map of key/values that belong
 	// to this Item.
 	Metadata() (map[string]interface{}, error)
+}
+
+type ItemPage struct {
+	Prefixes []string
+	Items    []Item
+	Cursor   string
 }
 
 // Config represents key/value configuration.

--- a/swift/container.go
+++ b/swift/container.go
@@ -1,13 +1,14 @@
 package swift
 
 import (
+	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
+	"unicode/utf8"
 
 	"github.com/graymeta/stow"
 	"github.com/ncw/swift"
+	"github.com/pkg/errors"
 )
 
 type container struct {
@@ -29,33 +30,59 @@ func (c *container) Item(id string) (stow.Item, error) {
 	return c.getItem(id)
 }
 
-func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+func (c *container) Browse(prefix, delimiter, cursor string, count int) (*stow.ItemPage, error) {
 	params := &swift.ObjectsOpts{
 		Limit:  count,
 		Marker: cursor,
 		Prefix: prefix,
 	}
+	r, sz := utf8.DecodeRuneInString(delimiter)
+	if r == utf8.RuneError {
+		if sz > 0 {
+			return nil, fmt.Errorf("Bad delimiter %v", delimiter)
+		}
+	} else {
+		params.Delimiter = r
+	}
 	objects, err := c.client.Objects(c.id, params)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	items := make([]stow.Item, len(objects))
-	for i, obj := range objects {
 
-		items[i] = &item{
+	var prefixes []string
+	for _, obj := range objects {
+		if obj.PseudoDirectory {
+			prefixes = append(prefixes, obj.Name)
+		}
+	}
+
+	var items []stow.Item
+	for _, obj := range objects {
+		if obj.PseudoDirectory {
+			continue
+		}
+		items = append(items, &item{
 			id:           obj.Name,
 			container:    c,
 			client:       c.client,
 			hash:         obj.Hash,
 			size:         obj.Bytes,
 			lastModified: obj.LastModified,
-		}
+		})
 	}
 	marker := ""
 	if len(objects) == count {
 		marker = objects[len(objects)-1].Name
 	}
-	return items, marker, nil
+	return &stow.ItemPage{Prefixes: prefixes, Items: items, Cursor: marker}, nil
+}
+
+func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+	page, err := c.Browse(prefix, "", cursor, count)
+	if err != nil {
+		return nil, "", err
+	}
+	return page.Items, cursor, err
 }
 
 func (c *container) Put(name string, r io.Reader, size int64, metadata map[string]interface{}) (stow.Item, error) {


### PR DESCRIPTION
delimiter returns results in a directory-like fashion.
Results will contain only items whose names, aside from the
prefix, do not contain delimiter. Items whose names,
aside from the prefix, contain delimiter will have their name,
truncated after the delimiter, returned in prefixes.
Duplicate prefixes are omitted. Optional.

ref: https://godoc.org/cloud.google.com/go/storage#Query

This will allow us to build a file browser using Stow.