### PR TITLE
Ensure linux and Mac versions compile in 386 & arm architectures.

### DIFF
--- a/local/filedata_darwin.go
+++ b/local/filedata_darwin.go
@@ -43,8 +43,8 @@ func getFileMetadata(path string, info os.FileInfo) map[string]interface{} {
 	}
 
 	if stat := info.Sys().(*syscall.Stat_t); stat != nil {
-		m["atime"] = time.Unix(stat.Atimespec.Sec, stat.Atimespec.Nsec).Format(time.RFC3339Nano)
-		m["mtime"] = time.Unix(stat.Mtimespec.Sec, stat.Mtimespec.Nsec).Format(time.RFC3339Nano)
+		m["atime"] = time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec)).Format(time.RFC3339Nano)
+		m["mtime"] = time.Unix(int64(stat.Mtimespec.Sec), int64(stat.Mtimespec.Nsec)).Format(time.RFC3339Nano)
 		m["uid"] = stat.Uid
 		m["gid"] = stat.Gid
 	}
@@ -73,6 +73,6 @@ func getInodeinfo(fi os.FileInfo) (*inodeinfo, error) {
 	}
 	return &inodeinfo{
 		Ino:   statT.Ino,
-		NLink: statT.Nlink,
+		NLink: uint16(statT.Nlink),
 	}, nil
 }

--- a/local/filedata_linux.go
+++ b/local/filedata_linux.go
@@ -43,8 +43,8 @@ func getFileMetadata(path string, info os.FileInfo) map[string]interface{} {
 	}
 
 	if stat := info.Sys().(*syscall.Stat_t); stat != nil {
-		m["atime"] = time.Unix(stat.Atim.Sec, stat.Atim.Nsec).Format(time.RFC3339Nano)
-		m["mtime"] = time.Unix(stat.Mtim.Sec, stat.Mtim.Nsec).Format(time.RFC3339Nano)
+		m["atime"] = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)).Format(time.RFC3339Nano)
+		m["mtime"] = time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec)).Format(time.RFC3339Nano)
 		m["uid"] = stat.Uid
 		m["gid"] = stat.Gid
 	}
@@ -73,6 +73,6 @@ func getInodeinfo(fi os.FileInfo) (*inodeinfo, error) {
 	}
 	return &inodeinfo{
 		Ino:   statT.Ino,
-		NLink: statT.Nlink,
+		NLink: uint64(statT.Nlink),
 	}, nil
 }


### PR DESCRIPTION
When compiling with `GOOS=linux GOARCH=arm`, I get the following errors:
```sh
vendor/github.com/graymeta/stow/local/filedata_linux.go:46: cannot use stat.Atim.Sec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_linux.go:46: cannot use stat.Atim.Nsec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_linux.go:47: cannot use stat.Mtim.Sec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_linux.go:47: cannot use stat.Mtim.Nsec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_linux.go:76: cannot use statT.Nlink (type uint32) as type uint64 in field value
```

```sh
vendor/github.com/graymeta/stow/local/filedata_linux.go:76: cannot use statT.Nlink (type uint32) as type uint64 in field value
```

When compiling with `GOOS=darwin GOARCH=386`, I get the following errors:
```sh
# github.com/appscode/osm/vendor/github.com/graymeta/stow/local
vendor/github.com/graymeta/stow/local/filedata_darwin.go:46: cannot use stat.Atimespec.Sec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_darwin.go:46: cannot use stat.Atimespec.Nsec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_darwin.go:47: cannot use stat.Mtimespec.Sec (type int32) as type int64 in argument to time.Unix
vendor/github.com/graymeta/stow/local/filedata_darwin.go:47: cannot use stat.Mtimespec.Nsec (type int32) as type int64 in argument to time.Unix
```
