### PR TITLE
s3: ability to use IAM roles

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -17,6 +17,9 @@ import (
 const Kind = "s3"
 
 const (
+	// ConfigAuthType is an optional argument that defines whether to use an IAM role or access key based auth
+	ConfigAuthType = "auth_type"
+
 	// ConfigAccessKeyID is one key of a pair of AWS credentials.
 	ConfigAccessKeyID = "access_key_id"
 
@@ -38,14 +41,26 @@ const (
 func init() {
 
 	makefn := func(config stow.Config) (stow.Location, error) {
-		_, ok := config.Config(ConfigAccessKeyID)
-		if !ok {
-			return nil, errors.New("missing Access Key ID")
+
+		authType, ok := config.Config(ConfigAuthType)
+		if !ok || authType == "" {
+			authType = "accesskey"
 		}
 
-		_, ok = config.Config(ConfigSecretKey)
-		if !ok {
-			return nil, errors.New("missing Secret Key")
+		if !(authType == "accesskey" || authType == "iam") {
+			return nil, errors.New("invalid auth_type")
+		}
+
+		if authType == "accesskey" {
+			_, ok := config.Config(ConfigAccessKeyID)
+			if !ok {
+				return nil, errors.New("missing Access Key ID")
+			}
+
+			_, ok = config.Config(ConfigSecretKey)
+			if !ok {
+				return nil, errors.New("missing Secret Key")
+			}
 		}
 
 		_, ok = config.Config(ConfigRegion)
@@ -77,33 +92,31 @@ func init() {
 
 // Attempts to create a session based on the information given.
 func newS3Client(config stow.Config) (*s3.S3, error) {
+	authType, _ := config.Config(ConfigAuthType)
 	accessKeyID, _ := config.Config(ConfigAccessKeyID)
 	secretKey, _ := config.Config(ConfigSecretKey)
 	//	token, _ := config.Config(ConfigToken)
 	region, _ := config.Config(ConfigRegion)
 
-	var awsConfig *aws.Config
+	if authType == "" {
+		authType = "accesskey"
+	}
+
+	awsConfig := aws.NewConfig().
+		WithRegion(region).
+		WithHTTPClient(http.DefaultClient).
+		WithMaxRetries(aws.UseServiceDefaultRetries).
+		WithLogger(aws.NewDefaultLogger()).
+		WithLogLevel(aws.LogOff).
+		WithSleepDelay(time.Sleep)
+
+	if authType == "accesskey" {
+		awsConfig.WithCredentials(credentials.NewStaticCredentials(accessKeyID, secretKey, ""))
+	}
 
 	endpoint, ok := config.Config(ConfigEndpoint)
-	if !ok {
-		awsConfig = aws.NewConfig().
-			WithCredentials(credentials.NewStaticCredentials(accessKeyID, secretKey, "")).
-			WithRegion(region).
-			WithHTTPClient(http.DefaultClient).
-			WithMaxRetries(aws.UseServiceDefaultRetries).
-			WithLogger(aws.NewDefaultLogger()).
-			WithLogLevel(aws.LogOff).
-			WithSleepDelay(time.Sleep)
-	} else {
-		awsConfig = aws.NewConfig().
-			WithCredentials(credentials.NewStaticCredentials(accessKeyID, secretKey, "")).
-			WithEndpoint(endpoint).
-			WithRegion(region).
-			WithHTTPClient(http.DefaultClient).
-			WithMaxRetries(aws.UseServiceDefaultRetries).
-			WithLogger(aws.NewDefaultLogger()).
-			WithLogLevel(aws.LogOff).
-			WithSleepDelay(time.Sleep).
+	if ok {
+		awsConfig.WithEndpoint(endpoint).
 			WithDisableSSL(true).
 			WithS3ForcePathStyle(true)
 	}

--- a/s3/stow_iam_test.go
+++ b/s3/stow_iam_test.go
@@ -1,0 +1,26 @@
+// +build iam
+
+package s3
+
+import (
+	"os"
+	"testing"
+
+	"github.com/graymeta/stow"
+	"github.com/graymeta/stow/test"
+)
+
+func TestStowIAM(t *testing.T) {
+	region := os.Getenv("S3REGION")
+
+	if region == "" {
+		t.Skip("skipping test because missing S3REGION")
+	}
+
+	config := stow.ConfigMap{
+		"auth_type": "iam",
+		"region":    region,
+	}
+
+	test.All(t, "s3", config)
+}

--- a/s3/stow_test.go
+++ b/s3/stow_test.go
@@ -1,9 +1,11 @@
+// build +disabled
 package s3
 
 import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -82,4 +84,15 @@ func TestPrepMetadataFailureWithNonStringValues(t *testing.T) {
 
 	_, err := prepMetadata(m)
 	is.Err(err)
+}
+
+func TestInvalidAuthtype(t *testing.T) {
+	is := is.New(t)
+
+	config := stow.ConfigMap{
+		"auth_type": "foo",
+	}
+	_, err := stow.Dial("s3", config)
+	is.Err(err)
+	is.True(strings.Contains(err.Error(), "invalid auth_type"))
 }


### PR DESCRIPTION
Allows a user to configure Stow to use an IAM role (in actuality, the default credentials chain) to authenticate to s3.