### PR TITLE
S3:session.New deprecated, use NewSession()

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -130,7 +130,10 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		awsConfig.WithDisableSSL(true)
 	}
 
-	sess := session.New(awsConfig)
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, "", err
+	}
 	if sess == nil {
 		return nil, "", errors.New("creating the S3 session")
 	}


### PR DESCRIPTION
It is found that session.New() is deprecated in aws-sdk-go 

Furthermore, if errors are encountered, then the AWS sdk doesn't return proper errors with
the deprecated method. Thus, switch to NewSession which has the same functionality along with proper error messages.