### PR TITLE
Changes s3 container.getItem() to use HeadObject instead of GetObject…

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -163,20 +163,19 @@ func (c *container) Region() string {
 // May be simpler to just stick it in PUT and and do a request every time, please vouch
 // for this if so.
 func (c *container) getItem(id string) (*item, error) {
-	params := &s3.GetObjectInput{
+	params := &s3.HeadObjectInput{
 		Bucket: aws.String(c.name),
 		Key:    aws.String(id),
 	}
 
-	res, err := c.client.GetObject(params)
+	res, err := c.client.HeadObject(params)
 	if err != nil {
 		// stow needs ErrNotFound to pass the test but amazon returns an opaque error
-		if strings.Contains(err.Error(), "NoSuchKey") {
+		if strings.Contains(err.Error(), "NotFound") {
 			return nil, stow.ErrNotFound
 		}
 		return nil, errors.Wrap(err, "getItem, getting the object")
 	}
-	defer res.Body.Close()
 
 	etag := cleanEtag(*res.ETag) // etag string value contains quotations. Remove them.
 	md, err := parseMetadata(res.Metadata)


### PR DESCRIPTION
…, as all we need at that point is the metadata and properties, not the body, which might be huge.  Item.Open() calls GetObject(), and it's inefficient to do it 2x for one item.