### PR TITLE
Fixes Bug in #171

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -78,7 +78,7 @@ func (c *container) Items(prefix, startAfter string, count int) ([]stow.Item, st
 
 	// Create a marker and determine if the list of items to retrieve is complete.
 	// If not, the last file is the input to the value of after which item to start
-	startAfter := ""
+	startAfter = ""
 	if *response.IsTruncated {
 		startAfter = containerItems[len(containerItems)-1].Name()
 	}


### PR DESCRIPTION
https://github.com/graymeta/stow/commit/fa2b4acd2b4ed9ce0d94fea1e28ef6f0666a71a3

/go/src/github.com/graymeta/stow/s3/container.go:81:13: no new variables on left side of :=