### PR TITLE
Bring back use of cursor in s3 container

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -41,12 +41,12 @@ func (c *container) Item(id string) (stow.Item, error) {
 
 // Items sends a request to retrieve a list of items that are prepended with
 // the prefix argument. The 'cursor' variable facilitates pagination.
-func (c *container) Items(prefix, startAfter string, count int) ([]stow.Item, string, error) {
+func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
 	itemLimit := int64(count)
 
 	params := &s3.ListObjectsV2Input{
 		Bucket:     aws.String(c.Name()),
-		StartAfter: &startAfter,
+		StartAfter: &cursor,
 		MaxKeys:    &itemLimit,
 		Prefix:     &prefix,
 	}


### PR DESCRIPTION
Follow up to https://github.com/graymeta/stow/pull/171/ where cursor was removed but shouldnt've been