### PR TITLE
Local: mimic the path semantics of cloud backends

### DIFF
--- a/local/item.go
+++ b/local/item.go
@@ -27,11 +27,12 @@ const (
 )
 
 type item struct {
-	path     string
-	infoOnce sync.Once // protects info
-	info     os.FileInfo
-	infoErr  error
-	metadata map[string]interface{}
+	path          string
+	contPrefixLen int
+	infoOnce      sync.Once // protects info
+	info          os.FileInfo
+	infoErr       error
+	metadata      map[string]interface{}
 }
 
 func (i *item) ID() string {
@@ -39,7 +40,7 @@ func (i *item) ID() string {
 }
 
 func (i *item) Name() string {
-	return filepath.Base(i.path)
+	return filepath.ToSlash(i.path[i.contPrefixLen:])
 }
 
 func (i *item) Size() (int64, error) {
@@ -92,7 +93,7 @@ func (i *item) ensureInfo() error {
 }
 
 func (i *item) setMetadata(info os.FileInfo) error {
-	fileMetadata := getFileMetadata(i.path, info) // retrieve file metadata
+	fileMetadata := getFileMetadata(i.path, info)
 	i.metadata = fileMetadata
 	return nil
 }

--- a/local/item_test.go
+++ b/local/item_test.go
@@ -2,6 +2,9 @@ package local_test
 
 import (
 	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -122,4 +125,35 @@ func TestSymLink(t *testing.T) {
 			break
 		}
 	}
+}
+
+func TestItemFromURL(t *testing.T) {
+	//A file-system path /a/b/c can be broken into (container, name)
+	//either as (/a, b/c) or as (/a/b,c). This test imposes
+	//the convention that the name is the last path component.
+	is := is.New(t)
+	testDir, teardown, err := setup()
+	is.NoErr(err)
+	defer teardown()
+	os.MkdirAll(filepath.Join(testDir, "a", "b"), 0777)
+	ioutil.WriteFile(filepath.Join(testDir, "a", "f2"), []byte("abc"), 0666)
+	ioutil.WriteFile(filepath.Join(testDir, "a", "b", "f3"), []byte("abc"), 0666)
+
+	cfg := stow.ConfigMap{"path": testDir}
+	l, err := stow.Dial(local.Kind, cfg)
+	is.NoErr(err)
+
+	item2, err := l.ItemByURL(&url.URL{
+		Scheme: "file",
+		Path:   filepath.Join(testDir, "a", "f2"),
+	})
+	is.NoErr(err)
+	is.Equal(item2.Name(), "f2")
+
+	item3, err := l.ItemByURL(&url.URL{
+		Scheme: "file",
+		Path:   filepath.Join(testDir, "a", "b", "f3"),
+	})
+	is.NoErr(err)
+	is.Equal(item3.Name(), "f3")
 }

--- a/test/test.go
+++ b/test/test.go
@@ -72,8 +72,9 @@ func All(t *testing.T, kind string, config stow.Config) {
 		}
 	}()
 
-	// create two containers
-	c1 := createContainer(is, location, "stowtest"+randName(10))
+	// create three containers
+	c1Name := "stowtest" + randName(10)
+	c1 := createContainer(is, location, c1Name)
 	c2 := createContainer(is, location, "stowtest"+randName(10))
 	c3 := createContainer(is, location, "stowtest"+randName(10))
 	is.NotEqual(c1.ID(), c2.ID())
@@ -92,7 +93,9 @@ func All(t *testing.T, kind string, config stow.Config) {
 
 	// add three items to c1 + add metadata to one item, assert if the implementation allows.
 	// Tests metadata retrieval on PUTs.
-	item1, skip1 := putItem(is, c1, "a_first/the item", "item one", md1)
+	item1Content := "item one"
+	item1Name := "a_first/the item"
+	item1, skip1 := putItem(is, c1, item1Name, item1Content, md1)
 	is.OK(item1)
 	if !skip1 {
 		is.NoErr(checkMetadata(t, is, item1, md1))
@@ -170,6 +173,12 @@ func All(t *testing.T, kind string, config stow.Config) {
 	is.OK(c1copy)
 	is.Equal(c1copy.ID(), c1.ID())
 
+	// get container by name
+	c1copy2, err := location.Container(c1Name)
+	is.NoErr(err)
+	is.OK(c1copy2)
+	is.Equal(c1copy2.ID(), c1.ID())
+
 	// get container that doesn't exist
 	noContainer, err := location.Container(c1.ID() + "nope")
 	is.Equal(stow.ErrNotFound, err)
@@ -182,7 +191,7 @@ func All(t *testing.T, kind string, config stow.Config) {
 	is.Equal(item1copy.ID(), item1.ID())
 	is.Equal(item1copy.Name(), item1.Name())
 	is.Equal(size(is, item1copy), size(is, item1))
-	is.Equal(readItemContents(is, item1copy), "item one")
+	is.Equal(readItemContents(is, item1copy), item1Content)
 	is.OK(etag(t, is, item1copy))
 	if !skip1 {
 		is.NoErr(checkMetadata(t, is, item1copy, md1))
@@ -201,6 +210,19 @@ func All(t *testing.T, kind string, config stow.Config) {
 	is.OK(item1b)
 	is.Equal(item1b.ID(), item1.ID())
 	is.Equal(etag(t, is, item1b), etag(t, is, item1copy))
+
+	// get item by name
+	item1copy2, err := c1copy2.Item(item1Name)
+	is.NoErr(err)
+	is.OK(item1copy2)
+	is.Equal(item1copy2.ID(), item1.ID())
+	is.Equal(item1copy2.Name(), item1.Name())
+	is.Equal(size(is, item1copy2), len(item1Content))
+	is.Equal(readItemContents(is, item1copy2), item1Content)
+	is.OK(etag(t, is, item1copy2))
+	if !skip1 {
+		is.NoErr(checkMetadata(t, is, item1copy2, md1))
+	}
 
 	// **************************************************
 	// Walking


### PR DESCRIPTION
This fixes #170

Store the Item's relative path to its container, not
its full path. When constructing container-based items,
treat relative paths as relative to the container, but keep
supporting absolute paths as well.

This is analogous to cloud backends, and so **container.Item("name")**
means the same thing in all backends - it means an item called "name"
that is stored inside the container.

On the other hand, we still want to support
container.Item("/full/path/to/name"), because the full path is the ID
of the Item. So this patch interprets an absolute path as the full
path of the item, and converts that to a relative path for internal
storage.