### PR TITLE
Use s3 head instead of get to retrieve item metadata

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,13 +15,44 @@
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date"
+  ]
   revision = "77a52603f06947221c672f10275abc9bf2c7d557"
   version = "v8.3.0"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/sts"
+  ]
   revision = "1850f427c33c2558a2118dc55c1cf95a633d7432"
   version = "v1.10.27"
 
@@ -50,6 +81,16 @@
   revision = "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e"
 
 [[projects]]
+  name = "github.com/graymeta/stow"
+  packages = [
+    ".",
+    "local",
+    "test"
+  ]
+  revision = "40ddb0743e48a0b979b7dc57ff214a686b0e1ef2"
+  version = "v0.1.0"
+
+[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
@@ -76,30 +117,55 @@
 [[projects]]
   branch = "release-branch.go1.8"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "186fd3fc8194a5e9980a82230d69c1ff7134229f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
   revision = "9a379c6b3e95a790ffc43293c2a78dee0d7b6e20"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
-  packages = ["gensupport","googleapi","googleapi/internal/uritemplates","storage/v1"]
+  packages = [
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "storage/v1"
+  ]
   revision = "98825bb0065da4054e5da6db34f5fc598e50bc24"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9669b6203ee98d781a69726537e19d7fbfb1bdf3441ba58111d3208fff0c225f"
+  inputs-digest = "194f0eac039a7353c41bbdbae8c995a03d66f3035126b9c0a72698aa53872e9f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,16 +81,6 @@
   revision = "ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e"
 
 [[projects]]
-  name = "github.com/graymeta/stow"
-  packages = [
-    ".",
-    "local",
-    "test"
-  ]
-  revision = "40ddb0743e48a0b979b7dc57ff214a686b0e1ef2"
-  version = "v0.1.0"
-
-[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,8 +21,8 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "77a52603f06947221c672f10275abc9bf2c7d557"
-  version = "v8.3.0"
+  revision = "5432abe734f8d95c78340cd56712f912906e6514"
+  version = "v8.3.1"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
@@ -156,6 +156,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "194f0eac039a7353c41bbdbae8c995a03d66f3035126b9c0a72698aa53872e9f"
+  inputs-digest = "4bfa9379e5cba5c73f8fcb51c8e91b74e7d9155db89f26ace5717bc25a5100c4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,9 +25,9 @@
   name = "github.com/Azure/azure-sdk-for-go"
   version = "10.2.1-beta"
 
-[[constraint]]
+[[override]]
   name = "github.com/Azure/go-autorest"
-  version = "~8.1.1"
+  version = "~8.3.0"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ runcontainer:
 	docker run -v $(WORKSPACE):/mnt/src/github.com/graymeta/stow builder-stow
 
 deps:
-	go get github.com/tebeka/go2xunit
-	go get -u github.com/golang/dep/cmd/dep
+	@rm -rf vendor*
+	@which go2xunit || (go get github.com/tebeka/go2xunit)
+	@which dep || (go get -u github.com/golang/dep/cmd/dep)
 	dep ensure
 
 test: clean deps vet

--- a/s3/container.go
+++ b/s3/container.go
@@ -33,8 +33,9 @@ func (c *container) Name() string {
 	return c.name
 }
 
-// Item returns a stow.Item instance of a container based on the
-// name of the container and the key representing
+// Item returns a stow.Item instance of a container based on the name of the container and the key representing. The
+// retrieved item only contains metadata about the object. This ensures that only the minimum amount of information is
+// transferred. Calling item.Open() will actually do a get request and open a stream to read from.
 func (c *container) Item(id string) (stow.Item, error) {
 	return c.getItem(id)
 }
@@ -164,12 +165,12 @@ func (c *container) Region() string {
 // May be simpler to just stick it in PUT and and do a request every time, please vouch
 // for this if so.
 func (c *container) getItem(id string) (*item, error) {
-	params := &s3.GetObjectInput{
+	params := &s3.HeadObjectInput{
 		Bucket: aws.String(c.name),
 		Key:    aws.String(id),
 	}
 
-	res, err := c.client.GetObject(params)
+	res, err := c.client.HeadObject(params)
 	if err != nil {
 		// stow needs ErrNotFound to pass the test but amazon returns an opaque error
 		if strings.Contains(err.Error(), "NoSuchKey") {
@@ -177,7 +178,6 @@ func (c *container) getItem(id string) (*item, error) {
 		}
 		return nil, errors.Wrap(err, "getItem, getting the object")
 	}
-	defer res.Body.Close()
 
 	etag := cleanEtag(*res.ETag) // etag string value contains quotations. Remove them.
 	md, err := parseMetadata(res.Metadata)


### PR DESCRIPTION
Doing container.Item(id) shouldn't send a GetObject request because that actually gets the object bytes and for large objects that might not be the desired behavior.
I changed container.Item(id) to send a HeadObject request instead. It'll still retrieve the same set of properties/metadata it used to.
item.Open() sends a separate Get request anyway to retrieve the io.ReaderCloser which will continue to be the case.