### PR TITLE
Fix panic in local adapter if Lstat fails

### DIFF
--- a/local/item.go
+++ b/local/item.go
@@ -83,18 +83,17 @@ func (i *item) ensureInfo() error {
 	i.infoOnce.Do(func() {
 		i.info, i.infoErr = os.Lstat(i.path) // retrieve item file info
 
-		i.infoErr = i.setMetadata(i.info) // merge file and metadata maps
 		if i.infoErr != nil {
 			return
 		}
+		i.setMetadata(i.info) // merge file and metadata maps
 	})
 	return i.infoErr
 }
 
-func (i *item) setMetadata(info os.FileInfo) error {
+func (i *item) setMetadata(info os.FileInfo) {
 	fileMetadata := getFileMetadata(i.path, info) // retrieve file metadata
 	i.metadata = fileMetadata
-	return nil
 }
 
 // Metadata gets stat information for the file.


### PR DESCRIPTION
If Lstat fails (for example, if the file doesn't exist on disk) we're not checking for an error before using the fileinfo (which could be nil) and thus causes a panic. There is no need to return an error from the
setMetadata function as there is nothing inside that function that returns an error