### PR TITLE
GP-1158: fix s3 compatible ItemByURL issue with Cloudian storage

### DIFF
--- a/s3/location.go
+++ b/s3/location.go
@@ -174,12 +174,10 @@ func (l *location) ItemByURL(url *url.URL) (stow.Item, error) {
 		return it, err
 	}
 
-	urlParts := strings.Split(url.Path, "/")
-	if len(urlParts) < 2 {
-		return nil, errors.New("parsing ItemByURL URL")
-	}
-	containerName := urlParts[0]
-	itemName := strings.Join(urlParts[1:], "/")
+	// url looks like this: s3://<containerName>/<itemName>
+	// example: s3://graymeta-demo/DPtest.txt
+	containerName := url.Host
+	itemName := strings.TrimPrefix(url.Path, "/")
 
 	c, err := l.Container(containerName)
 	if err != nil {


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-1158

The old parsing code was setting the container name to an empty string, which was then passed along to the HeadObject call which was returning a 404