### PR TITLE
add support for v2 signing in s3

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -45,6 +45,11 @@ const (
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
 	ConfigDisableSSL = "disable_ssl"
+
+	// ConfigV2Signing is an optional config value for signing requests with the v2 signature.
+	// Its default value is "false", to enable set to "true".
+	// This feature is useful for s3-compatible blob stores -- ie minio.
+	ConfigV2Signing = "v2_signing"
 )
 
 func init() {
@@ -163,6 +168,11 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 	}
 
 	s3Client := s3.New(sess)
+
+	usev2, ok := config.Config(ConfigV2Signing)
+	if ok && usev2 == "true" {
+		setv2Handlers(s3Client)
+	}
 
 	return s3Client, endpoint, nil
 }

--- a/s3/v2signer.go
+++ b/s3/v2signer.go
@@ -1,0 +1,234 @@
+/*
+Copyright (c) 2013 Damien Le Berrigaud and Nick Wade
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package s3
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	signatureVersion = "2"
+	signatureMethod  = "HmacSHA1"
+	timeFormat       = "2006-01-02T15:04:05Z"
+)
+
+type signer struct {
+	// Values that must be populated from the request
+	Request     *http.Request
+	Time        time.Time
+	Credentials *credentials.Credentials
+	Debug       aws.LogLevelType
+	Logger      aws.Logger
+
+	Query        url.Values
+	stringToSign string
+	signature    string
+}
+
+var s3ParamsToSign = map[string]bool{
+	"acl":                          true,
+	"location":                     true,
+	"logging":                      true,
+	"notification":                 true,
+	"partNumber":                   true,
+	"policy":                       true,
+	"requestPayment":               true,
+	"torrent":                      true,
+	"uploadId":                     true,
+	"uploads":                      true,
+	"versionId":                    true,
+	"versioning":                   true,
+	"versions":                     true,
+	"response-content-type":        true,
+	"response-content-language":    true,
+	"response-expires":             true,
+	"response-cache-control":       true,
+	"response-content-disposition": true,
+	"response-content-encoding":    true,
+	"website":                      true,
+	"delete":                       true,
+}
+
+func setv2Handlers(svc *s3.S3) {
+	svc.Handlers.Build.PushBack(func(r *request.Request) {
+		parsedURL, err := url.Parse(r.HTTPRequest.URL.String())
+		if err != nil {
+			log.Fatal("Failed to parse URL", err)
+		}
+		r.HTTPRequest.URL.Opaque = parsedURL.Path
+	})
+
+	svc.Handlers.Sign.Clear()
+	svc.Handlers.Sign.PushBack(Sign)
+	svc.Handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
+}
+
+// Sign requests with signature version 2.
+//
+// Will sign the requests with the service config's Credentials object
+// Signing is skipped if the credentials is the credentials.AnonymousCredentials
+// object.
+func Sign(req *request.Request) {
+	// If the request does not need to be signed ignore the signing of the
+	// request if the AnonymousCredentials object is used.
+	if req.Config.Credentials == credentials.AnonymousCredentials {
+		return
+	}
+
+	v2 := signer{
+		Request:     req.HTTPRequest,
+		Time:        req.Time,
+		Credentials: req.Config.Credentials,
+		Debug:       req.Config.LogLevel.Value(),
+		Logger:      req.Config.Logger,
+	}
+
+	req.Error = v2.Sign()
+
+	if req.Error != nil {
+		return
+	}
+}
+
+func (v2 *signer) Sign() error {
+	credValue, err := v2.Credentials.Get()
+	if err != nil {
+		return err
+	}
+	accessKey := credValue.AccessKeyID
+	var (
+		md5, ctype, date, xamz string
+		xamzDate               bool
+		sarray                 []string
+	)
+
+	headers := v2.Request.Header
+	params := v2.Request.URL.Query()
+	parsedURL, err := url.Parse(v2.Request.URL.String())
+	if err != nil {
+		return err
+	}
+	host, canonicalPath := parsedURL.Host, parsedURL.Path
+	v2.Request.Header["Host"] = []string{host}
+	v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
+
+	for k, v := range headers {
+		k = strings.ToLower(k)
+		switch k {
+		case "content-md5":
+			md5 = v[0]
+		case "content-type":
+			ctype = v[0]
+		case "date":
+			if !xamzDate {
+				date = v[0]
+			}
+		default:
+			if strings.HasPrefix(k, "x-amz-") {
+				vall := strings.Join(v, ",")
+				sarray = append(sarray, k+":"+vall)
+				if k == "x-amz-date" {
+					xamzDate = true
+					date = ""
+				}
+			}
+		}
+	}
+	if len(sarray) > 0 {
+		sort.StringSlice(sarray).Sort()
+		xamz = strings.Join(sarray, "\n") + "\n"
+	}
+
+	expires := false
+	if v, ok := params["Expires"]; ok {
+		expires = true
+		date = v[0]
+		params["AWSAccessKeyId"] = []string{accessKey}
+	}
+
+	sarray = sarray[0:0]
+	for k, v := range params {
+		if s3ParamsToSign[k] {
+			for _, vi := range v {
+				if vi == "" {
+					sarray = append(sarray, k)
+				} else {
+					sarray = append(sarray, k+"="+vi)
+				}
+			}
+		}
+	}
+	if len(sarray) > 0 {
+		sort.StringSlice(sarray).Sort()
+		canonicalPath = canonicalPath + "?" + strings.Join(sarray, "&")
+	}
+
+	v2.stringToSign = strings.Join([]string{
+		v2.Request.Method,
+		md5,
+		ctype,
+		date,
+		xamz + canonicalPath,
+	}, "\n")
+	hash := hmac.New(sha1.New, []byte(credValue.SecretAccessKey))
+	hash.Write([]byte(v2.stringToSign))
+	v2.signature = base64.StdEncoding.EncodeToString(hash.Sum(nil))
+
+	if expires {
+		params["Signature"] = []string{string(v2.signature)}
+	} else {
+		headers["Authorization"] = []string{"AWS " + accessKey + ":" + string(v2.signature)}
+	}
+
+	if v2.Debug.Matches(aws.LogDebugWithSigning) {
+		v2.logSigningInfo()
+	}
+	return nil
+}
+
+const logSignInfoMsg = `DEBUG: Request Signature:
+---[ STRING TO SIGN ]--------------------------------
+%s
+---[ SIGNATURE ]-------------------------------------
+%s
+-----------------------------------------------------`
+
+func (v2 *signer) logSigningInfo() {
+	msg := fmt.Sprintf(logSignInfoMsg, v2.stringToSign, v2.signature)
+	v2.Logger.Log(msg)
+}


### PR DESCRIPTION
Implementation for #197

Using `test.go`:

```go
package main

import (
	"log"

	"github.com/graymeta/stow"
	"github.com/graymeta/stow/s3"
)

func main() {
	config := stow.ConfigMap{
		s3.ConfigAccessKeyID: "L47K8F7E0EL32TMWJTEM",
		s3.ConfigSecretKey:   "FLTrFbnpbniUij0os7I8kSpSVXWRuHdsemBIijfW",
		s3.ConfigEndpoint:    "http://localhost:9000",
		s3.ConfigDisableSSL:  "true",
		s3.ConfigV2Signing:   "true",
	}
	location, err := stow.Dial("s3", config)
	if err != nil {
		log.Fatalf("s3 connect error: %s", err)
	}
	defer location.Close()
	err = stow.WalkContainers(location, stow.NoPrefix, 100, func(c stow.Container, err error) error {
		if err != nil {
			return err
		}
		log.Println(c.Name())
		err = stow.Walk(c, stow.NoPrefix, 100, func(item stow.Item, err error) error {
			if err != nil {
				return err
			}
			log.Println("\t" + item.Name())
			return nil
		})
		if err != nil {
			log.Fatalf("s3 list items: %s", err)
		}
		return nil
	})
	if err != nil {
		log.Fatalf("s3 bucket list error: %s", err)
	}
}
```

We were able to valid the signing was occurring with the following
output.

```bash
○ → go run test.go
2019/02/08 17:28:20 DEBUG: Request s3/ListBuckets Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET / HTTP/1.1
Host: localhost:9000
User-Agent: aws-sdk-go/1.13.11 (go1.11.4; darwin; amd64)
Authorization: AWS L47K8F7E0EL32TMWJTEM:TEGYT3+hTcJ/X6cb52yiZGKGy6Y=
x-amz-date: Sat, 09 Feb 2019 00:28:20 UTC
Accept-Encoding: gzip

-----------------------------------------------------
2019/02/08 17:28:20 DEBUG: Response s3/ListBuckets Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Date: Sat, 09 Feb 2019 00:28:20 GMT
Server: Minio/RELEASE.2019-02-06T21-16-36Z
Vary: Origin
X-Amz-Request-Id: 15818A9082246420
X-Minio-Deployment-Id: 53577c22-9a41-4820-854b-07d21e362095
X-Xss-Protection: 1; mode=block

-----------------------------------------------------
2019/02/08 17:28:20 <?xml version="1.0" encoding="UTF-8"?>
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4</ID><DisplayName></DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>
```