### PR TITLE
[google] remove validation of 'json' config field

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -26,26 +26,15 @@ const (
 
 func init() {
 	validatefn := func(config stow.Config) error {
-		_, ok := config.Config(ConfigJSON)
-		if !ok {
-			return errors.New("missing JSON configuration")
-		}
-
-		_, ok = config.Config(ConfigProjectId)
+		_, ok := config.Config(ConfigProjectId)
 		if !ok {
 			return errors.New("missing Project ID")
 		}
 		return nil
 	}
 	makefn := func(config stow.Config) (stow.Location, error) {
-		_, ok := config.Config(ConfigJSON)
-		if !ok {
-			return nil, errors.New("missing JSON configuration")
-		}
-
-		_, ok = config.Config(ConfigProjectId)
-		if !ok {
-			return nil, errors.New("missing Project ID")
+		if err := validatefn(config); err != nil {
+			return nil, err
 		}
 
 		// Create a new client


### PR DESCRIPTION
The `json` config field is optional and if unused, default application
credentials will be used.