### PR TITLE
Adding a stow adapter to work with remote filesystems via sftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Stow provides implementations for storage services, blob stores, cloud storage e
 * Microsoft Azure Blob Storage
 * Openstack Swift (with auth v2)
 * Oracle Storage Cloud Service
+* SFTP
 
 ## Concepts
 

--- a/sftp/config.go
+++ b/sftp/config.go
@@ -39,11 +39,17 @@ const (
 	// found in the known_hosts file). If this is not specified, or is set to an
 	// empty string, the host key validation will be disabled.
 	ConfigHostPublicKey = "host_public_key"
+
+	// ConfigBasePath is the path to the root folder on the remote server. It can be
+	// relative to the user's home directory, or an absolute path. If not set, or
+	// set to an empty string, the user's home directory will be used.
+	ConfigBasePath = "base_path"
 )
 
 type conf struct {
 	host      string
 	port      int
+	basePath  string
 	sshConfig ssh.ClientConfig
 }
 
@@ -119,6 +125,11 @@ func parseConfig(config stow.Config) (*conf, error) {
 		}
 
 		c.sshConfig.HostKeyCallback = ssh.FixedHostKey(parsedHostKey)
+	}
+
+	c.basePath, ok = config.Config(ConfigBasePath)
+	if !ok || c.basePath == "" {
+		c.basePath = "."
 	}
 
 	return &c, nil

--- a/sftp/config.go
+++ b/sftp/config.go
@@ -1,0 +1,165 @@
+package sftp
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/graymeta/stow"
+	"github.com/pkg/errors"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// Kind represents the name of the location/storage type.
+const Kind = "sftp"
+
+const (
+	// ConfigHost is the hostname or IP address to connect to.
+	ConfigHost = "host"
+
+	// ConfigPort is the numeric port number the ssh daemon is listening on.
+	ConfigPort = "port"
+
+	// ConfigUsername is the username of the user to connect as.
+	ConfigUsername = "username"
+
+	// ConfigPassword is the password use to authentiate with. Can be used instead
+	// of a private key (if your server allows this).
+	ConfigPassword = "password"
+
+	// ConfigPrivateKey is a private ssh key to use to authenticate. These are the
+	// bytes representing the key, not the path on disk to the key file.
+	ConfigPrivateKey = "private_key"
+
+	// ConfigPrivateKeyPassphrase is an optional passphrase to use with the private key.
+	ConfigPrivateKeyPassphrase = "private_key_passphrase"
+
+	// ConfigHostPublicKey is the public host key (in the same format as would be
+	// found in the known_hosts file). If this is not specified, or is set to an
+	// empty string, the host key validation will be disabled.
+	ConfigHostPublicKey = "host_public_key"
+)
+
+type conf struct {
+	host      string
+	port      int
+	sshConfig ssh.ClientConfig
+}
+
+func (c conf) Host() string {
+	return fmt.Sprintf("%s:%d", c.host, c.port)
+}
+
+func parseConfig(config stow.Config) (*conf, error) {
+	var c conf
+	var ok bool
+
+	c.host, ok = config.Config(ConfigHost)
+	if !ok || c.host == "" {
+		return nil, errors.New("invalid hostname")
+	}
+
+	port, ok := config.Config(ConfigPort)
+	if !ok {
+		return nil, errors.New("port not specified")
+
+	}
+	var err error
+	c.port, err = strconv.Atoi(port)
+	if err != nil || c.port < 1 {
+		return nil, errors.New("invalid port configuration")
+	}
+
+	c.sshConfig.User, ok = config.Config(ConfigUsername)
+	if !ok || c.sshConfig.User == "" {
+		return nil, errors.New("invalid username")
+	}
+
+	// If a private key is specified, load it up and add it to the list of
+	// authentication methods to attempt against the server.
+	privKey, ok := config.Config(ConfigPrivateKey)
+	if ok && privKey != "" {
+		// If a passphrase for the key is specified, use it to unlock the key.
+		passphrase, _ := config.Config(ConfigPrivateKeyPassphrase)
+		var signer ssh.Signer
+		if passphrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase([]byte(privKey), []byte(passphrase))
+			if err != nil {
+				return nil, errors.Wrap(err, "parsing key with passphrase")
+			}
+		} else {
+			signer, err = ssh.ParsePrivateKey([]byte(privKey))
+			if err != nil {
+				return nil, errors.Wrap(err, "parsing key")
+			}
+		}
+		c.sshConfig.Auth = append(c.sshConfig.Auth, ssh.PublicKeys(signer))
+	}
+
+	// If a password was specified, add password auth to the list of auth methods
+	// to try.
+	password, _ := config.Config(ConfigPassword)
+	if password != "" {
+		c.sshConfig.Auth = append(c.sshConfig.Auth, ssh.Password(password))
+	}
+
+	// Require at least 1 authentication method.
+	if len(c.sshConfig.Auth) == 0 {
+		return nil, errors.New("no authentication methods specified")
+	}
+
+	// Start by ignoring host keys. If a host key is specified in the configuration,
+	// use that to validate the remote server.
+	c.sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+	if hostKey, ok := config.Config(ConfigHostPublicKey); ok && hostKey != "" {
+		_, _, parsedHostKey, _, _, err := ssh.ParseKnownHosts([]byte(hostKey))
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing host key")
+		}
+
+		c.sshConfig.HostKeyCallback = ssh.FixedHostKey(parsedHostKey)
+	}
+
+	return &c, nil
+}
+
+func init() {
+	validatefn := func(config stow.Config) error {
+		_, err := parseConfig(config)
+		return err
+	}
+	makefn := func(config stow.Config) (stow.Location, error) {
+		c, err := parseConfig(config)
+		if err != nil {
+			return nil, err
+		}
+
+		loc := &location{
+			config: c,
+		}
+
+		// Connect to the remote server and perform the SSH handshake.
+		loc.sshClient, err = ssh.Dial("tcp", c.Host(), &c.sshConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "ssh connection")
+		}
+
+		// Open an SFTP session over an existing ssh connection.
+		loc.sftpClient, err = sftp.NewClient(loc.sshClient)
+		if err != nil {
+			// close the ssh connection if the sftp connection fails. This avoids leaking
+			// the ssh connection.
+			loc.Close()
+			return nil, errors.Wrap(err, "sftp connection")
+		}
+
+		return loc, nil
+	}
+
+	kindfn := func(u *url.URL) bool {
+		return u.Scheme == Kind
+	}
+
+	stow.Register(Kind, makefn, kindfn, validatefn)
+}

--- a/sftp/container.go
+++ b/sftp/container.go
@@ -1,0 +1,204 @@
+package sftp
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/graymeta/stow"
+)
+
+type container struct {
+	name     string
+	location *location
+}
+
+// ID returns a string value which represents the name of the container.
+func (c *container) ID() string {
+	return c.name
+}
+
+// Name returns a string value which represents the name of the container.
+func (c *container) Name() string {
+	return c.name
+}
+
+// Item returns a stow.Item instance of a container based on the name of the
+// container and the file.
+func (c *container) Item(id string) (stow.Item, error) {
+	path := filepath.Join(c.name, filepath.FromSlash(id))
+	info, err := c.location.sftpClient.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, stow.ErrNotFound
+		}
+		return nil, err
+	}
+
+	if info.IsDir() {
+		return nil, errors.New("unexpected directory")
+	}
+
+	return &item{
+		container: c,
+		path:      id,
+		size:      info.Size(),
+		modTime:   info.ModTime(),
+		md:        getFileMetadata(info),
+	}, nil
+}
+
+// Items sends a request to retrieve a list of items that are prepended with
+// the prefix argument. The 'cursor' variable facilitates pagination.
+func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string, error) {
+	var entries []entry
+	entries, cursor, err := c.getFolderItems([]entry{}, prefix, "", c.name, cursor, count, false)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Convert entries to []stow.Item
+	sItems := make([]stow.Item, len(entries))
+	for i := range entries {
+		sItems[i] = entries[i].item
+	}
+
+	return sItems, cursor, nil
+}
+
+const separator = "/"
+
+// we use this struct to keep track of stuff when walking.
+type entry struct {
+	Name    string
+	ID      string
+	RelPath string
+	item    stow.Item
+}
+
+func (c *container) getFolderItems(entries []entry, prefix, relPath, id, cursor string, limit int, initialStart bool) ([]entry, string, error) {
+	relCursor := cursor
+	if relPath != "" {
+		relCursor = strings.TrimPrefix(cursor, relPath+separator)
+	}
+	cursorPieces := strings.Split(relCursor, separator)
+	files, err := c.location.sftpClient.ReadDir(id)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var start bool
+	if cursorPieces[0] == "" {
+		start = true
+	}
+
+	for i, file := range files {
+		fileRelPath := filepath.Join(relPath, file.Name())
+		if !start && cursorPieces[0] != "" && (file.Name() >= cursorPieces[0] || fileRelPath >= cursor) {
+			start = true
+			if file.Name() == cursorPieces[0] && !file.IsDir() {
+				continue
+			}
+		}
+
+		if !start {
+			continue
+		}
+
+		if file.IsDir() {
+			var err error
+			var retCursor string
+			entries, retCursor, err = c.getFolderItems(entries, prefix, fileRelPath, filepath.Join(id, file.Name()), cursor, limit, true)
+			if err != nil {
+				return nil, "", err
+			}
+			if len(entries) != limit {
+				continue
+			}
+
+			if retCursor == "" && i < len(files)-1 {
+				retCursor = entries[len(entries)-1].RelPath
+			}
+
+			return entries, retCursor, nil
+		}
+
+		// TODO: prefix could be optimized to not look down paths that don't match,
+		// but this is a quick/cheap first implementation.
+		filePath := strings.TrimPrefix(filepath.Join(id, file.Name()), c.name+"/")
+		if !strings.HasPrefix(filePath, prefix) {
+			continue
+		}
+
+		entries = append(
+			entries,
+			entry{
+				Name:    file.Name(),
+				ID:      filepath.Join(id, file.Name()),
+				RelPath: fileRelPath,
+				item: &item{
+					container: c,
+					path:      filePath,
+					size:      file.Size(),
+					modTime:   file.ModTime(),
+					md:        getFileMetadata(file),
+				},
+			},
+		)
+		if len(entries) == limit {
+			retCursor := entries[len(entries)-1].RelPath
+			if i == len(files)-1 {
+				retCursor = ""
+			}
+			return entries, retCursor, nil
+		}
+	}
+
+	return entries, "", nil
+}
+
+// RemoveItem removes a file from the remote server.
+func (c *container) RemoveItem(id string) error {
+	return c.location.sftpClient.Remove(filepath.Join(c.name, filepath.FromSlash(id)))
+}
+
+// Put sends a request to upload content to the container.
+func (c *container) Put(name string, r io.Reader, size int64, metadata map[string]interface{}) (stow.Item, error) {
+	if len(metadata) > 0 {
+		return nil, stow.NotSupported("metadata")
+	}
+
+	path := filepath.Join(c.name, filepath.FromSlash(name))
+	item := &item{
+		container: c,
+		path:      name,
+		size:      size,
+	}
+	err := c.location.sftpClient.MkdirAll(filepath.Dir(path))
+	if err != nil {
+		return nil, err
+	}
+	f, err := c.location.sftpClient.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	n, err := io.Copy(f, r)
+	if err != nil {
+		return nil, err
+	}
+	if n != size {
+		return nil, errors.New("bad size")
+	}
+
+	info, err := c.location.sftpClient.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	item.modTime = info.ModTime()
+	item.md = getFileMetadata(info)
+
+	return item, nil
+}

--- a/sftp/item.go
+++ b/sftp/item.go
@@ -1,0 +1,80 @@
+package sftp
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/graymeta/stow/local"
+)
+
+type item struct {
+	container *container
+	path      string
+	size      int64
+	modTime   time.Time
+	md        map[string]interface{}
+}
+
+// ID returns a string value that represents the name of a file.
+func (i *item) ID() string {
+	return i.path
+}
+
+// Name returns a string value that represents the name of the file.
+func (i *item) Name() string {
+	return i.path
+}
+
+// Size returns the size of an item in bytes.
+func (i *item) Size() (int64, error) {
+	return i.size, nil
+}
+
+// URL returns a formatted string identifying this asset.
+// Format is: sftp://<username>@<host>:<port>/<container>/<path to file>
+func (i *item) URL() *url.URL {
+	genericURL := fmt.Sprintf("/%s/%s", i.container.Name(), i.Name())
+	return &url.URL{
+		Scheme: Kind,
+		User:   url.User(i.container.location.config.sshConfig.User),
+		Path:   genericURL,
+		Host:   i.container.location.config.Host(),
+	}
+}
+
+// Open retrieves specic information about an item based on the container name
+// and path of the file within the container. This response includes the body of
+// resource which is returned along with an error.
+func (i *item) Open() (io.ReadCloser, error) {
+	return i.container.location.sftpClient.Open(fmt.Sprintf("%s/%s", i.container.Name(), i.Name()))
+}
+
+// LastMod returns the last modified date of the item.
+func (i *item) LastMod() (time.Time, error) {
+	return i.modTime, nil
+}
+
+// ETag returns the ETag value from the properies field of an item.
+func (i *item) ETag() (string, error) {
+	return i.modTime.String(), nil
+}
+
+// Metadata returns some item level metadata about the item.
+func (i *item) Metadata() (map[string]interface{}, error) {
+	return i.md, nil
+}
+
+func getFileMetadata(info os.FileInfo) map[string]interface{} {
+	return map[string]interface{}{
+		// Reuse the constants from the local package for consistency.
+		local.MetadataIsDir: info.IsDir(),
+		local.MetadataName:  info.Name(),
+		local.MetadataMode:  fmt.Sprintf("%o", info.Mode()),
+		local.MetadataModeD: fmt.Sprintf("%v", uint32(info.Mode())),
+		local.MetadataPerm:  info.Mode().String(),
+		local.MetadataSize:  info.Size(),
+	}
+}

--- a/sftp/item.go
+++ b/sftp/item.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/graymeta/stow/local"
@@ -49,7 +50,13 @@ func (i *item) URL() *url.URL {
 // and path of the file within the container. This response includes the body of
 // resource which is returned along with an error.
 func (i *item) Open() (io.ReadCloser, error) {
-	return i.container.location.sftpClient.Open(fmt.Sprintf("%s/%s", i.container.Name(), i.Name()))
+	return i.container.location.sftpClient.Open(
+		filepath.Join(
+			i.container.location.config.basePath,
+			i.container.Name(),
+			i.Name(),
+		),
+	)
 }
 
 // LastMod returns the last modified date of the item.

--- a/sftp/location.go
+++ b/sftp/location.go
@@ -24,7 +24,7 @@ type location struct {
 
 // CreateContainer creates a new container, in this case a directory on the remote server.
 func (l *location) CreateContainer(containerName string) (stow.Container, error) {
-	if err := l.sftpClient.Mkdir(containerName); err != nil {
+	if err := l.sftpClient.Mkdir(filepath.Join(l.config.basePath, containerName)); err != nil {
 		return nil, err
 	}
 
@@ -36,7 +36,7 @@ func (l *location) CreateContainer(containerName string) (stow.Container, error)
 
 // Containers returns a slice of the Container interface, a cursor, and an error.
 func (l *location) Containers(prefix, cursor string, count int) ([]stow.Container, string, error) {
-	infos, err := l.sftpClient.ReadDir(".")
+	infos, err := l.sftpClient.ReadDir(l.config.basePath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -99,7 +99,7 @@ func (l *location) Close() error {
 
 // Container retrieves a stow.Container based on its name which must be exact.
 func (l *location) Container(id string) (stow.Container, error) {
-	fi, err := l.sftpClient.Stat(id)
+	fi, err := l.sftpClient.Stat(filepath.Join(l.config.basePath, id))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, stow.ErrNotFound
@@ -117,7 +117,7 @@ func (l *location) Container(id string) (stow.Container, error) {
 
 // RemoveContainer removes a container by name.
 func (l *location) RemoveContainer(id string) error {
-	return recurseRemove(l.sftpClient, id)
+	return recurseRemove(l.sftpClient, filepath.Join(l.config.basePath, id))
 }
 
 // recurseRemove recursively purges content from a path.

--- a/sftp/location.go
+++ b/sftp/location.go
@@ -1,0 +1,166 @@
+package sftp
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/graymeta/stow"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+type location struct {
+	// we keep config here so that we can access the server information (username/host)
+	// when constructing the item urls.
+	config     *conf
+	sshClient  *ssh.Client
+	sftpClient *sftp.Client
+}
+
+// CreateContainer creates a new container, in this case a directory on the remote server.
+func (l *location) CreateContainer(containerName string) (stow.Container, error) {
+	if err := l.sftpClient.Mkdir(containerName); err != nil {
+		return nil, err
+	}
+
+	return &container{
+		location: l,
+		name:     containerName,
+	}, nil
+}
+
+// Containers returns a slice of the Container interface, a cursor, and an error.
+func (l *location) Containers(prefix, cursor string, count int) ([]stow.Container, string, error) {
+	infos, err := l.sftpClient.ReadDir(".")
+	if err != nil {
+		return nil, "", err
+	}
+
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name() < infos[j].Name() })
+
+	var cont []stow.Container
+	for i, v := range infos {
+		if !v.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(v.Name(), prefix) {
+			continue
+		}
+
+		if v.Name() <= cursor {
+			continue
+		}
+
+		cont = append(cont, &container{
+			location: l,
+			name:     v.Name(),
+		})
+
+		if len(cont) == count {
+			// Check if any of the remaining entries are directories. If they are, then return
+			// v.Name() as the cursor. This prevents us from serving up an empty page of
+			// containers if all of the entries after v.Name() are files.
+			for j := i + 1; j < len(infos); j++ {
+				if infos[j].IsDir() {
+					return cont, v.Name(), nil
+				}
+			}
+			return cont, "", nil
+		}
+	}
+
+	return cont, "", nil
+}
+
+// Close closes the underlying sftp/ssh connections.
+func (l *location) Close() error {
+	var errs error
+
+	if l.sftpClient != nil {
+		if err := l.sftpClient.Close(); err != nil {
+			errs = multierror.Append(errs, errors.Wrap(err, "closing sftp conn"))
+		}
+	}
+
+	if l.sshClient != nil {
+		if err := l.sshClient.Close(); err != nil {
+			errs = multierror.Append(errs, errors.Wrap(err, "closing ssh conn"))
+		}
+	}
+
+	return errs
+}
+
+// Container retrieves a stow.Container based on its name which must be exact.
+func (l *location) Container(id string) (stow.Container, error) {
+	fi, err := l.sftpClient.Stat(id)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, stow.ErrNotFound
+		}
+		return nil, err
+	}
+	if !fi.IsDir() {
+		return nil, stow.ErrNotFound
+	}
+	return &container{
+		location: l,
+		name:     id,
+	}, nil
+}
+
+// RemoveContainer removes a container by name.
+func (l *location) RemoveContainer(id string) error {
+	return recurseRemove(l.sftpClient, id)
+}
+
+// recurseRemove recursively purges content from a path.
+func recurseRemove(client *sftp.Client, path string) error {
+	infos, err := client.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range infos {
+		if !v.IsDir() {
+			return errors.Errorf("directory not empty - %q", v.Name())
+		}
+		if err := recurseRemove(client, filepath.Join(path, v.Name())); err != nil {
+			return err
+		}
+	}
+
+	return client.RemoveDirectory(path)
+}
+
+// ItemByURL retrieves a stow.Item by parsing the URL.
+func (l *location) ItemByURL(u *url.URL) (stow.Item, error) {
+	// expect sftp://<username>@<host>:<port>/<container>/<path to file>
+	// example: sftp://someuser@example.com:22/foo/blah/baz.txt
+
+	urlParts := strings.Split(u.Path, "/")
+	if len(urlParts) < 3 {
+		return nil, errors.New("parsing ItemByURL unexpected length")
+	}
+
+	containerName := urlParts[1]
+	itemName := strings.Join(urlParts[2:], "/")
+
+	c, err := l.Container(containerName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "ItemByURL, getting container %q", containerName)
+	}
+
+	i, err := c.Item(itemName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "ItemByURL, getting item %q", itemName)
+	}
+
+	return i, nil
+}

--- a/sftp/stow_test.go
+++ b/sftp/stow_test.go
@@ -139,6 +139,15 @@ func TestStow(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("stow_tests - with base path", func(t *testing.T) {
+		basePath := os.Getenv("SFTP_BASEPATH")
+		if basePath == "" {
+			t.Skip("skipping base paths test due to SFTP_BASEPATH not being set")
+		}
+		config[ConfigBasePath] = basePath
+		test.All(t, Kind, config)
+	})
 }
 
 func setupFiles(t *testing.T, c stow.Container, files []string) {

--- a/sftp/stow_test.go
+++ b/sftp/stow_test.go
@@ -1,0 +1,163 @@
+package sftp
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/graymeta/stow"
+	"github.com/graymeta/stow/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStow(t *testing.T) {
+	config := stow.ConfigMap{
+		ConfigHost:     os.Getenv("SFTP_HOST"),
+		ConfigPort:     os.Getenv("SFTP_PORT"),
+		ConfigUsername: os.Getenv("SFTP_USERNAME"),
+	}
+	if config[ConfigHost] == "" ||
+		config[ConfigPort] == "" ||
+		config[ConfigUsername] == "" {
+		t.Skip("skipping tests because environment isn't configured")
+	}
+
+	b, err := ioutil.ReadFile(os.Getenv("SFTP_PRIVATE_KEY_FILE"))
+	require.NoError(t, err)
+	config[ConfigPrivateKey] = string(b)
+	config[ConfigPrivateKeyPassphrase] = os.Getenv("SFTP_PRIVATE_KEY_PASSPHRASE")
+
+	t.Run("stow_tests", func(t *testing.T) {
+		test.All(t, Kind, config)
+	})
+
+	t.Run("additional_tests", func(t *testing.T) {
+		location, err := stow.Dial(Kind, config)
+		require.NoError(t, err)
+		defer location.Close()
+
+		t.Run("set of files 1", func(t *testing.T) {
+			cont, err := location.CreateContainer("stowtest" + randName(10))
+			require.NoError(t, err)
+			defer location.RemoveContainer(cont.ID())
+
+			files := []string{
+				"a.jpg",
+				"bar/a.jpg",
+				"bar/b.jpg",
+				"bar/baz/a.jpg",
+				"bar/baz/b.jpg",
+				"foo/a.jpg",
+				"foo/b.jpg",
+				"z.jpg",
+			}
+
+			setupFiles(t, cont, files)
+
+			t.Run("no prefix, no cursor, len 4", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "", 4)
+				require.NoError(t, err)
+				require.Len(t, items, 4)
+				require.Equal(t, files[0], items[0].ID())
+				require.Equal(t, files[1], items[1].ID())
+				require.Equal(t, files[2], items[2].ID())
+				require.Equal(t, files[3], items[3].ID())
+				require.Equal(t, cursor, "bar/baz/a.jpg")
+			})
+
+			t.Run("no prefix, no cursor, len 5", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "", 5)
+				require.NoError(t, err)
+				require.Len(t, items, 5)
+				require.Equal(t, files[0], items[0].ID())
+				require.Equal(t, files[1], items[1].ID())
+				require.Equal(t, files[2], items[2].ID())
+				require.Equal(t, files[3], items[3].ID())
+				require.Equal(t, files[4], items[4].ID())
+				require.Equal(t, cursor, "bar/baz/b.jpg")
+			})
+
+			t.Run("no prefix, no cursor, len 100", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "", 100)
+				require.NoError(t, err)
+				require.Len(t, items, len(files))
+				require.Equal(t, "", cursor)
+			})
+
+			t.Run("no prefix, with cursor, len 100", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "bar/baz/a.jpg", 100)
+				require.NoError(t, err)
+				require.Len(t, items, 4)
+				require.Equal(t, "", cursor)
+			})
+		})
+
+		t.Run("set of files 2", func(t *testing.T) {
+			cont, err := location.CreateContainer("stowtest" + randName(10))
+			require.NoError(t, err)
+			defer location.RemoveContainer(cont.ID())
+
+			files := []string{
+				"bar/baz/a.jpg",
+				"bar/baz/b.jpg",
+				"bar/baz/c.jpg",
+				"bar/baz/d.jpg",
+				"bar/baz/e.jpg",
+			}
+
+			setupFiles(t, cont, files)
+
+			t.Run("no prefix, no cursor, len 3", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "", 3)
+				require.NoError(t, err)
+				require.Len(t, items, 3)
+				require.Equal(t, files[2], cursor)
+			})
+
+			t.Run("no prefix, no cursor, len 5", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "", 5)
+				require.NoError(t, err)
+				require.Len(t, items, 5)
+				require.Equal(t, "", cursor)
+			})
+
+			t.Run("no prefix, with cursor, len 5", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "bar/baz/b.jpg", 5)
+				require.NoError(t, err)
+				require.Len(t, items, 3)
+				require.Equal(t, "", cursor)
+			})
+
+			t.Run("no prefix, with cursor (a), len 5", func(t *testing.T) {
+				items, cursor, err := cont.Items("", "a", 5)
+				require.NoError(t, err)
+				require.Len(t, items, 5)
+				require.Equal(t, "", cursor)
+			})
+		})
+	})
+}
+
+func setupFiles(t *testing.T, c stow.Container, files []string) {
+	for _, file := range files {
+		_, err := c.Put(file, strings.NewReader(""), 0, nil)
+		require.NoError(t, err)
+	}
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func init() {
+	rand.Seed(int64(time.Now().Nanosecond()))
+}
+
+func randName(length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
Exposes all containers under the user's home dir as containers.
~Question: Do we want to specify a remote path/prefix instead of assuming home dir?~ YES

Supports either password auth or key based auth (key will work with or without a passphrase).

Supports remote host public key validation (if specified).

See the stow_test.go file for how to set up env vars for testing.