### PR TITLE
remove requirement for json

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -26,11 +26,6 @@ const (
 
 func init() {
 	validatefn := func(config stow.Config) error {
-		_, ok := config.Config(ConfigJSON)
-		if !ok {
-			return errors.New("missing JSON configuration")
-		}
-
 		_, ok = config.Config(ConfigProjectId)
 		if !ok {
 			return errors.New("missing Project ID")
@@ -38,11 +33,6 @@ func init() {
 		return nil
 	}
 	makefn := func(config stow.Config) (stow.Location, error) {
-		_, ok := config.Config(ConfigJSON)
-		if !ok {
-			return nil, errors.New("missing JSON configuration")
-		}
-
 		_, ok = config.Config(ConfigProjectId)
 		if !ok {
 			return nil, errors.New("missing Project ID")


### PR DESCRIPTION
The json string is optional when creating the client. It is a bit weird to have a json in the config as an empty string.