### PR TITLE
Fix Google Cloud Storage object metadata handling

### DIFF
--- a/google/item.go
+++ b/google/item.go
@@ -58,8 +58,7 @@ func (i *Item) LastMod() (time.Time, error) {
 	return i.lastModified, nil
 }
 
-// Metadata returns a nil map and no error.
-// TODO: Implement this.
+// Metadata returns a map with object metadata.
 func (i *Item) Metadata() (map[string]interface{}, error) {
 	return i.metadata, nil
 }


### PR DESCRIPTION
Google Cloud Storage object has [fixed and user-defined metadata](https://cloud.google.com/storage/docs/metadata). 
Fixed metadata:
- Access control metadata
- Cache-Control
- Content-Disposition
- Content-Encoding
- Content-Language
- Content-Type

Currently item.Metadata() would only return map of user defined metadata (often just means an empty map). Fixed metadata are fields of storage.Object and would be missing in item metadata. For an example there would be no way of knowing the object content type.

This change will provide also "fixed metadata" from the stow item metadata map and allows setting them when writing. In addition to tests in this repo I have tries these changes out in my own project.

Let me know if something about this could be improved!