### PR TITLE
Fix container.Items nil ptr panic with some non-AWS impls of S3

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -60,7 +60,7 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 	var containerItems []stow.Item
 
 	for _, object := range response.Contents {
-		if *object.StorageClass == "GLACIER" {
+		if object.StorageClass != nil && *object.StorageClass == "GLACIER" {
 			continue
 		}
 		etag := cleanEtag(*object.ETag) // Copy etag value and remove the strings.


### PR DESCRIPTION
During testing using stow with some non-AWS S3 implementation's stow's ``container.Items`` panics due to a nil pointer dereference. This PR checks to ensure the said pointer ``object.StorageClass *string`` is not nil before dereferencing.

Fix:
```
Panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb3801e]
....
panic({0xc3e3a0, 0x1395120})
	~/go/src/runtime/panic.go:1038 +0x215
github.com/graymeta/stow/s3.(*container).Items(0xc0001fc100, {0xc0007a86f0, 0x14}, {0x0, 0x0}, 0x41)
	~/go/src/github.com/graymeta/stow/s3/container.go:63 +0x27e
```