### PR TITLE
Handle nil pointer for s3 container

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"io"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,6 +61,12 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 	var containerItems []stow.Item
 
 	for _, object := range response.Contents {
+		if object.StorageClass == nil {
+			if object.Key != nil {
+				log.Printf("Return Storage Class is empty for object %s \n", *object.Key)
+			}
+			continue
+		}
 		if *object.StorageClass == "GLACIER" {
 			continue
 		}


### PR DESCRIPTION
`object.StorageClass` is accessed without first checked for nil pointer. This caused for a `nil pointer deference` errors in some cases .

This PR adds a guard for that, as well as some logging to gather information on cases where `object.StorageClass` is `nil`